### PR TITLE
Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Example `git-conventional-commits.json`
   },
 
   "changelog" : {
+    "date": "header",
     "commitTypes": [
       "feat",
       "fix",
@@ -84,6 +85,10 @@ Example `git-conventional-commits.json`
     * e.g. Jira issue pattern `[A-Z]{3,}-\\d+`
  
 * `changelog` 
+  * `data` format the date in the change, `header` will format the date in teh header
+    and `quote` will formate the date below the version header in a `quote` block.
+    * default: `header`
+    * Options: `header`, `quote`
   * `commitTypes` filter commits by type
     * a subset of `convention.commitTypes` plus
       * `merge` commits

--- a/git-conventional-commits.default.json
+++ b/git-conventional-commits.default.json
@@ -20,6 +20,7 @@
   },
 
   "changelog" : {
+    "date": "header",
     "commitTypes": [
       "feat",
       "fix",

--- a/git-conventional-commits.json
+++ b/git-conventional-commits.json
@@ -20,6 +20,7 @@
   },
 
   "changelog" : {
+    "date": "header",
     "commitTypes": [
       "feat",
       "fix",

--- a/lib/changelogGenerator.js
+++ b/lib/changelogGenerator.js
@@ -6,8 +6,19 @@ module.exports = function(config) {
     // ------ generate version headline
     let changelogCommitRangeMarkdown = markdownCommitRange(firstChangelogCommit, lastChangelogCommit);
 
-    changelogMarkdown += `## **${release || lastChangelogCommit}**` +
-      ` <sub><sup>${yyyy_mm_dd(new Date())} (${changelogCommitRangeMarkdown})</sup></sub>\n`;
+    // Format the date in the changelog
+    const dateFormat = (['header','quote'].indexOf(config.date.toLowerCase()) > -1) ? config.date.toLowerCase() : 'header' || 'header'
+    switch(dateFormat) {
+      case 'quote':
+        changelogMarkdown += `## **${release || lastChangelogCommit}**\n\n`
+        changelogMarkdown += `> ${yyyy_mm_dd(new Date())} (${changelogCommitRangeMarkdown})\n`
+        break;
+      case 'header':
+      default:
+        changelogMarkdown += `## **${release || lastChangelogCommit}**` +
+          ` <sub><sup>${yyyy_mm_dd(new Date())} (${changelogCommitRangeMarkdown})</sup></sub>\n`;
+        break;
+    }
 
     changelogMarkdown += '\n';
 

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -26,6 +26,7 @@ function load(configFile) {
   if (configOverride.changelog) {
     const changelogConfig = config.changelog;
     const changelogOverride = configOverride.changelog;
+    changelogConfig.date = changelogOverride.date || changelogConfig.date;
     changelogConfig.commitTypes = changelogOverride.commitTypes || changelogConfig.commitTypes;
     changelogConfig.commitScopes = changelogOverride.commitScopes || changelogConfig.commitScopes;
     changelogConfig.commitIgnoreRegexPattern = changelogOverride.commitIgnoreRegexPattern || changelogConfig.commitIgnoreRegexPattern;
@@ -51,6 +52,7 @@ function defaultConfig() {
       issueRegexPattern: null,
     },
     changelog: {
+      date: "header",
       commitTypes: ['feat', 'fix'],
       commitScopes: null,
       commitIgnoreRegexPattern: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "git-conventional-commits",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "execa": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-conventional-commits",
-  "version": "1.0.10",
+  "version": "1.1.0",
   "description": "git conventional commits util",
   "licence": "MIT",
   "main": "cli.js",


### PR DESCRIPTION
Implement date format for changelog.

* Option 1: date format in header
* Option 2: Date Format in Quote block

Option 1 remains default for backwards compatibility

### Generated Code

```markdown
## **21.06**

> 2021-06-28 (a7dabd8...a2708e4)

### Features
```

### Rendered Example

<hr>

## **21.06**

> 2021-06-28 (a7dabd8...a2708e4)

### Features