### PR TITLE
fix: Update exclude commitType filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Example `git-conventional-commits.json`
     * a subset of `convention.commitTypes` plus
       * `merge` commits
     * if not set or empty commit type filter is disabled
-    * e.g. `["feat", "fix", "merge" , "?"]`
+    * e.g. `["feat", "fix", "merge"]`
   * `commitScopes` filter commits by scopes
     * a subset of `convention.commitScopes`
     * if not set or empty commit scope filter is disabled

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Example `git-conventional-commits.json`
       "merge",
       "?"
     ],
+    "includeInvalidCommits": true,
     "commitScopes": [],
     "commitIgnoreRegexPattern": "^WIP ",
     "headlines": {
@@ -98,8 +99,11 @@ Example `git-conventional-commits.json`
     * a subset of `convention.commitScopes`
     * if not set or empty commit scope filter is disabled
     * e.g. `["ui"]`
+  * `includeInvalidCommits` include commits without valid type
+    * if set to false all commits with undefined `commitTypes` will be removed from changelog 
+    * default `true`
   * `commitIgnoreRegexPattern` filter commits by commit subject regex
-    * default `^WIP `  
+  * default `^WIP `  
   * `headlines` a map of headline identifier and actual headline
     * a subset of `changelog.commitTypes` plus
       * `breakingChange` Breaking Changes Section

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Example `git-conventional-commits.json`
       "feat",
       "fix",
       "perf",
-      "merge",
-      "?"
+      "merge"
     ],
     "includeInvalidCommits": true,
     "commitScopes": [],
@@ -92,18 +91,16 @@ Example `git-conventional-commits.json`
   * `commitTypes` filter commits by type
     * a subset of `convention.commitTypes` plus
       * `merge` commits
-      * `?` commits with unexpected message format
     * if not set or empty commit type filter is disabled
     * e.g. `["feat", "fix", "merge" , "?"]`
   * `commitScopes` filter commits by scopes
     * a subset of `convention.commitScopes`
     * if not set or empty commit scope filter is disabled
     * e.g. `["ui"]`
-  * `includeInvalidCommits` include commits without valid type
+  * `includeInvalidCommits` include commits without valid type: default: `true`
     * if set to false all commits with undefined `commitTypes` will be removed from changelog 
-    * default `true`
   * `commitIgnoreRegexPattern` filter commits by commit subject regex
-  * default `^WIP `  
+    * default `^WIP `  
   * `headlines` a map of headline identifier and actual headline
     * a subset of `changelog.commitTypes` plus
       * `breakingChange` Breaking Changes Section

--- a/git-conventional-commits.default.json
+++ b/git-conventional-commits.default.json
@@ -26,6 +26,7 @@
       "perf",
       "merge"
     ],
+    "includeInvalidCommits": true,
     "commitIgnoreRegexPattern": "^WIP ",
     "headlines": {
       "feat": "Features",

--- a/git-conventional-commits.json
+++ b/git-conventional-commits.json
@@ -26,6 +26,7 @@
       "perf",
       "merge"
     ],
+    "includeInvalidCommits": true,
     "commitIgnoreRegexPattern": "^WIP ",
     "headlines": {
       "feat": "Features",

--- a/lib/commands/commandChangelog.js
+++ b/lib/commands/commandChangelog.js
@@ -59,8 +59,10 @@ exports.handler = async function (argv) {
         .filter( // filter by commit messages regex
             commit => ![commit.subject, commit.body].join("\n\n").match(config.changelog.commitIgnoreRegex()))
         .filter(// filter by commit type
-            commit => !commit.type || !config.changelog.commitTypes || !config.changelog.commitTypes.length
-                || config.changelog.commitTypes.includes(commit.type))
+            commit => (!commit.type || commit.type === undefined) && config.changelog.commitTypes.includes('?') // undefined commit type
+                || !config.changelog.commitTypes || !config.changelog.commitTypes.length // no filter at all
+                || config.changelog.commitTypes.includes(commit.type) // commit type in filter list
+        )
         .filter( // filter by commit scope
             commit => !commit.scope || !config.changelog.commitScopes || !config.changelog.commitScopes.length
                 || config.changelog.commitScopes.includes(commit.scope));

--- a/lib/commands/commandChangelog.js
+++ b/lib/commands/commandChangelog.js
@@ -59,9 +59,9 @@ exports.handler = async function (argv) {
         .filter( // filter by commit messages regex
             commit => ![commit.subject, commit.body].join("\n\n").match(config.changelog.commitIgnoreRegex()))
         .filter(// filter by commit type
-            commit => (!commit.type && config.changelog.commitTypes.includes('?')) // undefined commit type
+            commit => (!commit.type && config.changelog.includeInvalidCommits != false) // undefined commit type
                 || !config.changelog.commitTypes || !config.changelog.commitTypes.length // no filter at all
-                || config.changelog.commitTypes.includes(commit.type) // commit type in filter list
+                || (commit.type!==undefined && config.changelog.commitTypes.includes(commit.type)) // commit type in filter list
         )
         .filter( // filter by commit scope
             commit => !commit.scope || !config.changelog.commitScopes || !config.changelog.commitScopes.length

--- a/lib/commands/commandChangelog.js
+++ b/lib/commands/commandChangelog.js
@@ -59,7 +59,7 @@ exports.handler = async function (argv) {
         .filter( // filter by commit messages regex
             commit => ![commit.subject, commit.body].join("\n\n").match(config.changelog.commitIgnoreRegex()))
         .filter(// filter by commit type
-            commit => (!commit.type || commit.type === undefined) && config.changelog.commitTypes.includes('?') // undefined commit type
+            commit => (!commit.type && config.changelog.commitTypes.includes('?')) // undefined commit type
                 || !config.changelog.commitTypes || !config.changelog.commitTypes.length // no filter at all
                 || config.changelog.commitTypes.includes(commit.type) // commit type in filter list
         )

--- a/lib/commands/commandChangelog.js
+++ b/lib/commands/commandChangelog.js
@@ -59,7 +59,7 @@ exports.handler = async function (argv) {
         .filter( // filter by commit messages regex
             commit => ![commit.subject, commit.body].join("\n\n").match(config.changelog.commitIgnoreRegex()))
         .filter(// filter by commit type
-            commit => (!commit.type && config.changelog.includeInvalidCommits != false) // undefined commit type
+            commit => (!commit.type && config.changelog.includeInvalidCommits) // undefined commit type
                 || !config.changelog.commitTypes || !config.changelog.commitTypes.length // no filter at all
                 || (commit.type!==undefined && config.changelog.commitTypes.includes(commit.type)) // commit type in filter list
         )

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -27,6 +27,10 @@ function load(configFile) {
     const changelogConfig = config.changelog;
     const changelogOverride = configOverride.changelog;
     changelogConfig.commitTypes = changelogOverride.commitTypes || changelogConfig.commitTypes;
+    changelogConfig.includeInvalidCommits = (changelogOverride.includeInvalidCommits !== undefined ?
+            changelogOverride.includeInvalidCommits === true :
+            changelogConfig.includeInvalidCommits
+    );
     changelogConfig.commitScopes = changelogOverride.commitScopes || changelogConfig.commitScopes;
     changelogConfig.commitIgnoreRegexPattern = changelogOverride.commitIgnoreRegexPattern || changelogConfig.commitIgnoreRegexPattern;
     changelogConfig.headlines = {
@@ -52,6 +56,7 @@ function defaultConfig() {
     },
     changelog: {
       commitTypes: ['feat', 'fix'],
+      includeInvalidCommits: true,
       commitScopes: null,
       commitIgnoreRegexPattern: null,
       headlines: {

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -27,10 +27,9 @@ function load(configFile) {
     const changelogConfig = config.changelog;
     const changelogOverride = configOverride.changelog;
     changelogConfig.commitTypes = changelogOverride.commitTypes || changelogConfig.commitTypes;
-    changelogConfig.includeInvalidCommits = (changelogOverride.includeInvalidCommits !== undefined ?
-            changelogOverride.includeInvalidCommits === true :
-            changelogConfig.includeInvalidCommits
-    );
+    changelogConfig.includeInvalidCommits = changelogOverride.includeInvalidCommits !== undefined 
+      ? changelogOverride.includeInvalidCommits === true
+      : changelogConfig.includeInvalidCommits;
     changelogConfig.commitScopes = changelogOverride.commitScopes || changelogConfig.commitScopes;
     changelogConfig.commitIgnoreRegexPattern = changelogOverride.commitIgnoreRegexPattern || changelogConfig.commitIgnoreRegexPattern;
     changelogConfig.headlines = {


### PR DESCRIPTION
filter commits for changelog generator if the commits type is undefined and the '?' is not in the changelog.commitTypes list.

I have a problem skipping undefined (?) commits in changelog generation.
My configuration [git-conventional-commits.txt](https://github.com/qoomon/git-conventional-commits/files/8126823/git-conventional-commits.txt) does not provide a commitType= '?'