### PR TITLE
Handle development version increments according to SemVer specification

### DIFF
--- a/lib/gitCommitConvention.js
+++ b/lib/gitCommitConvention.js
@@ -1,4 +1,5 @@
 const Git = require("./git");
+const { applyChangesToVersion } = require("./semver");
 
 module.exports = function(convention, commitAnchor = 'HEAD') {
 
@@ -57,16 +58,7 @@ module.exports = function(convention, commitAnchor = 'HEAD') {
       }
     });
 
-    if (changes.breaking > 0) {
-      version.major++;
-      version.minor = 0;
-      version.patch = 0;
-    } else if (changes.feature > 0) {
-      version.minor++;
-      version.patch = 0;
-    } else {
-      version.patch++;
-    }
+    applyChangesToVersion(version, changes);
 
     return `${version.major}.${version.minor}.${version.patch}`;
   }

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -1,13 +1,24 @@
 function applyChangesToVersion(version, changes) {
-  if (changes.breaking > 0) {
-    version.major++;
-    version.minor = 0;
-    version.patch = 0;
-  } else if (changes.feature > 0) {
-    version.minor++;
-    version.patch = 0;
+  // SemVer 2.0.0 §4: public api should not be considered stable when major version is 0
+  if (version.major === 0) {
+    // never change major version in development releases
+    if (changes.breaking > 0 || changes.feature > 0) {
+      version.minor++;
+      version.patch = 0;
+    } else {
+      version.patch++;
+    }
   } else {
-    version.patch++;
+    if (changes.breaking > 0) {
+      version.major++;
+      version.minor = 0;
+      version.patch = 0;
+    } else if (changes.feature > 0) {
+      version.minor++;
+      version.patch = 0;
+    } else {
+      version.patch++;
+    }
   }
 }
 

--- a/lib/semver.js
+++ b/lib/semver.js
@@ -1,0 +1,16 @@
+function applyChangesToVersion(version, changes) {
+  if (changes.breaking > 0) {
+    version.major++;
+    version.minor = 0;
+    version.patch = 0;
+  } else if (changes.feature > 0) {
+    version.minor++;
+    version.patch = 0;
+  } else {
+    version.patch++;
+  }
+}
+
+module.exports = {
+  applyChangesToVersion,
+};

--- a/test/semver.test.js
+++ b/test/semver.test.js
@@ -44,3 +44,13 @@ createApplyChangesTest("1.0.0", "1.0.0", "2.0.0");
 createApplyChangesTest("1.0.0", "0.1.1", "1.1.0");
 createApplyChangesTest("1.0.0", "1.1.0", "2.0.0");
 createApplyChangesTest("1.0.0", "1.0.1", "2.0.0");
+
+// pure changes (either major, minor or patch) to development version
+createApplyChangesTest("0.1.0", "0.0.1", "0.1.1");
+createApplyChangesTest("0.1.0", "0.1.0", "0.2.0");
+createApplyChangesTest("0.1.0", "1.0.0", "0.2.0");
+
+// mixed changes (at least two of major, minor or patch) to development version
+createApplyChangesTest("0.1.0", "0.1.1", "0.2.0");
+createApplyChangesTest("0.1.0", "1.1.0", "0.2.0");
+createApplyChangesTest("0.1.0", "1.0.1", "0.2.0");

--- a/test/semver.test.js
+++ b/test/semver.test.js
@@ -1,0 +1,46 @@
+const { applyChangesToVersion } = require("../lib/semver");
+
+const createApplyChangesTest = (versionString, changesString, expectedString) => {
+  test(`applyChangesToVersion - ${versionString} + ${changesString} -> ${expectedString}`, async () => {
+    // GIVEN
+    const p = s => parseInt(s, 10);
+    const v = versionString.split('.').map(p);
+    const c = changesString.split('.').map(p);
+    const e = expectedString.split('.').map(p);
+    const version = {
+      major: v[0],
+      minor: v[1],
+      patch: v[2],
+    };
+    const changes = {
+      breaking: c[0],
+      feature: c[1],
+      patch: c[2],
+    };
+
+
+    // WHEN
+    applyChangesToVersion(version, changes);
+
+
+    // THEN
+    expect(version).toEqual({
+      major: e[0],
+      minor: e[1],
+      patch: e[2],
+    });
+  });
+};
+
+// XXX
+// createApplyChangesTest("1.0.0", "0.0.0", "1.0.0");
+
+// pure changes (either major, minor or patch) to stable version
+createApplyChangesTest("1.0.0", "0.0.1", "1.0.1");
+createApplyChangesTest("1.0.0", "0.1.0", "1.1.0");
+createApplyChangesTest("1.0.0", "1.0.0", "2.0.0");
+
+// mixed changes (at least two of major, minor or patch) to stable version
+createApplyChangesTest("1.0.0", "0.1.1", "1.1.0");
+createApplyChangesTest("1.0.0", "1.1.0", "2.0.0");
+createApplyChangesTest("1.0.0", "1.0.1", "2.0.0");


### PR DESCRIPTION
As stated in [SemVer 2.0.0 §4](https://semver.org/#spec-item-4), breaking changes in development versions (0.y.z) are indicated by a patch or minor version increment. Currently this project treats development versions the same as stable versions.

This PR changes the version increment behavior for development versions by never updating the major version in development versions.

**Before**
```
0.1.0 + BREAKING CHANGE = 1.0.0
```

**After**
```
0.1.0 + BREAKING CHANGE = 0.2.0
```

I also added some basic tests to validate this behavior.