### PR TITLE
docs: fix release workflow instructions "docs" keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Example `git-conventional-commits.json`
 1. Update version in project files
     * Commit version bump `git commit -am'build(release): bump project version to <version>'`
 1. Generate change log by `git-conventional-commits changelog --release  <version> --file 'CHANGELOG.md'`
-    * Commit change log `git commit -am'doc(release): create <version> change log entry'`
+    * Commit change log `git commit -am'docs(release): create <version> change log entry'`
 1. Tag commit with version `git tag -a -m'build(release): <version>' '<version-prefix><version>'`
 1. Push all changes `git push`
 1. Build and upload artifacts


### PR DESCRIPTION
The default configuration json does not contain the "doc" type, but the "docs" type. The release workflow instructions should reflect that. I received a warning message when releasing my project with the default instructions.