### PR TITLE
fix: recognize breaking changes in version command

### DIFF
--- a/lib/gitCommitConvention.js
+++ b/lib/gitCommitConvention.js
@@ -51,7 +51,7 @@ module.exports = function (convention, commitAnchor = 'HEAD') {
                     acc.patches++;
                 }
                 return acc;
-            }, {breakingChanges: 0, features: 0, patches: 0});
+            }, {breaking: 0, features: 0, patches: 0});
 
             applyChangesToVersion(version, changes);
         }


### PR DESCRIPTION
Hi, I found another type-related bug. I don't know why the tests didn't catch this. Might be worth it to invest in some type annotations to check with `tsc`.

A naming mistake causes the accumulation of `breaking` changes to
yield `NaN` in case there is more than 0 breaking changes.  This was
caused by the reduction being initialized with a missnamed attribute
name (`breakingChanges` instead of `breaking`).

The `breaking` attribute was not set in the reduction, causing its
initial value to be `undefined`.  The increments for breaking changes
(`acc.breaking++`) therefore caused the evaluation of the expression
`undefined++`.  Therefore there were always `NaN` breaking changes
whenever there was more than one breaking change.