### PR TITLE
feat: add support for the pre-commit framework

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: conventional-commits
+  name: conventional-commits
+  description: "Util to generate Semantic Version and Markdown changelog and validate commit message"
+  entry: git-conventional-commits commit-msg-hook
+  stages: [commit-msg]
+  language: node

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: conventional-commits
   name: conventional-commits
-  description: "Util to generate Semantic Version and Markdown changelog and validate commit message"
+  description: "Util to validate commit message"
   entry: git-conventional-commits commit-msg-hook
   stages: [commit-msg]
   language: node

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
   entry: git-conventional-commits commit-msg-hook
   stages: [commit-msg]
   language: node
+  

--- a/README.md
+++ b/README.md
@@ -131,15 +131,15 @@ The hook can be created either manually or using the [pre-commit framework](http
         - id: conventional-commits
     ```
 
-  Please replace the placeholder `<revision>` with the desired revision from this repository.
+    Please replace the placeholder `<revision>` with the desired revision from this repository.
 1. Install the `pre-commit` framework with: 
-  ```
-  pip install pre-commit
-  ```
+    ```
+    pip install pre-commit
+    ```
 1. Install the commit-msg hook: 
-  ```
-  pre-commit install -t commit-msg
-  ```
+    ```
+    pre-commit install -t commit-msg
+    ```
 
 #### Setup manually
 * Setup Commit Message Hook to 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,31 @@ Example `git-conventional-commits.json`
  
 
 ### Automatically Validate Commit Message Convention before Commit
+
+To automatically validate commit messages, a git hook can be used in the `commit-msg` stage. 
+The hook can be created either manually or using the [pre-commit framework](https://pre-commit.com/).
+
+#### Setup with the pre-commit framework
+1. Create a file `.pre-commit-config.yaml` in the root directory of your repository with the following content: 
+    ```
+    repos:
+    - repo: https://github.com/qoomon/git-conventional-commits
+      rev: <revision>
+      hooks:
+        - id: conventional-commits
+    ```
+
+  Please replace the placeholder `<revision>` with the desired revision from this repository.
+1. Install the `pre-commit` framework with: 
+  ```
+  pip install pre-commit
+  ```
+1. Install the commit-msg hook: 
+  ```
+  pre-commit install -t commit-msg
+  ```
+
+#### Setup manually
 * Setup Commit Message Hook to 
   * Navigate to your repository directory `cd <repository-path>`
   * Create git hook directory `mkdir .git-hooks`


### PR DESCRIPTION
This PR adds support for the [pre-commit framework](https://pre-commit.com/).

Users can simply add the following section to their `.pre-commit-config.yaml`:
```
repos:
  - repo: https://github.com/MoritzWeber0/git-conventional-commits
    rev: 37941ef
    hooks:
      - id: conventional-commits
```
If it is merged, the new repository URL can of course be used.

After cloning a repository, users can just execute the following command to setup the `commit-msg` hook:
```
pre-commit install -t commit-msg
```