### PR TITLE
docs: add init.templatedir setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ see [CHANGELOG.md](CHANGELOG.md)
 * Create [config file](#config-file) `git-conventional-commits init`
 * Adjust config `git-conventional-commits.json` to your needs
 
+#### Global Setup
+* `mkdir -p .git-templates/hooks/`
+* create file `.git-templates/hooks/commit-msg` with following content:
+```
+#!/bin/sh
+git-conventional-commits commit-msg-hook "$1"
+```
+* `git config --global init.templatedir '~/.git-templates'`
+* re-use `git init` in existing repositories
+
+
 #### Commands
 ℹ add help parameter `-h` to commands to list all possible options
 ```

--- a/lib/commands/commandCommitMessageHook.js
+++ b/lib/commands/commandCommitMessageHook.js
@@ -12,7 +12,7 @@ exports.builder = function (yargs) {
     yargs.option('config', {
         alias: 'c',
         desc: 'Config file path',
-        default: Config.defaultPath,
+        default: fs.existsSync(Config.defaultPath) ? Config.defaultPath : Config.templatePath,
         requiresArg: true
     })
 }


### PR DESCRIPTION
By using global init.templatedir we can register the git-conventional-commits hook in every repository automatically.

For already existing repositories you only have to `git init` again. 

To prevent errors on repositories without the config-file default to `git-conventional-commits.default.json`.

IDEA: maybe create a global config file instead of using the `git-conventional-commits.default.json`