### PR TITLE
WIP: feat: adds parse git config to get origin url and cleanup to use for …

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -1,8 +1,24 @@
 const fs = require("fs");
+const ini = require("ini");
 const path = require("path");
 
 const defaultPath = "./git-conventional-commits.json";
 const templatePath = `${__dirname}/../../git-conventional-commits.default.json`;
+
+function getGitUrl() {
+    const gitConfig = ini.parse(fs.readFileSync('./.git/config', 'utf-8'));
+    let gitUrl = Object.keys(gitConfig).filter(key => key.indexOf('origin') !== -1).map(key => gitConfig[key].url)[0];
+
+    gitUrl = gitUrl.replace('.git', '');
+
+    if (gitUrl.indexOf('@') !== -1) {
+        gitUrl = gitUrl
+            .replace(":", "/")
+            .replace(/\w*@/, 'https://');
+    }
+
+    return gitUrl;
+}
 
 function load(configFile) {
     configFile = configFile || defaultPath;
@@ -38,10 +54,19 @@ function load(configFile) {
             ...changelogOverride.headlines
         };
 
-        changelogConfig.commitUrl = changelogOverride.commitUrl || changelogConfig.commitUrl;
-        changelogConfig.commitRangeUrl = changelogOverride.commitRangeUrl || changelogConfig.commitRangeUrl;
         changelogConfig.issueRegexPattern = changelogOverride.issueRegexPattern || changelogConfig.issueRegexPattern;
-        changelogConfig.issueUrl = changelogOverride.issueUrl || changelogConfig.issueUrl;
+
+        if (configOverride.changelog.useGitInfo) {
+            const gitUrl = getGitUrl();
+
+            changelogConfig.commitUrl = gitUrl + '/commit/%commit%';
+            changelogConfig.commitRangeUrl = gitUrl + '/compare/%from%...%to%?diff=split';
+            changelogConfig.issueUrl = gitUrl + '/issues/%issue%"';
+        } else {
+            changelogConfig.commitUrl = changelogOverride.commitUrl || changelogConfig.commitUrl;
+            changelogConfig.commitRangeUrl = changelogOverride.commitRangeUrl || changelogConfig.commitRangeUrl;
+            changelogConfig.issueUrl = changelogOverride.issueUrl || changelogConfig.issueUrl;
+        }
     }
     return config;
 }
@@ -82,7 +107,8 @@ function defaultConfig() {
             commitUrl: null,
             commitRangeUrl: null,
             issueRegexPattern: null,
-            issueUrl: null
+            issueUrl: null,
+            useGitInfo: false,
         }
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "git-conventional-commits",
       "version": "2.3.0",
       "dependencies": {
+        "ini": "^3.0.1",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -1807,6 +1808,14 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/ini": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz",
+      "integrity": "sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ==",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4818,6 +4827,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "ini": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-3.0.1.tgz",
+      "integrity": "sha512-it4HyVAUTKBc6m8e1iXWvXSTdndF7HbdN713+kvLrymxTaU4AUBWrJ4vEooP+V7fexnVD3LKcBshjGGPefSMUQ=="
     },
     "is-arrayish": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "repository": "github:qoomon/git-conventional-commits",
   "author": "",
   "dependencies": {
+    "ini": "^3.0.1",
     "yargs": "^17.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
To use a generic config file (f.e. for https://github.com/qoomon/git-conventional-commits/pull/118) it's necessary to parse the git url from actual repo - and not from file. 

Therefore we can use the .git/config file and rewrite the origin url.

In that case it could be heavy to match all existing git-tool routing-syntax (e.g. gitlab, github, bitbucket,...).