### PR TITLE
fix: Fixed WIP feature

### DIFF
--- a/lib/commands/commandChangelog.js
+++ b/lib/commands/commandChangelog.js
@@ -62,7 +62,7 @@ exports.handler = async function (argv) {
         includeInvalidCommits: config.changelog.includeInvalidCommits,
         commitTypes: config.changelog.commitTypes,
         commitScopes: config.changelog.commitScopes,
-        commitIgnoreRegexPattern: config.changelog.commitIgnoreRegex(),
+        commitIgnoreRegex: new RegExp(config.changelog.commitIgnoreRegexPattern, "m")
     });
 
     // ------ output -------------------------------------------------

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -79,7 +79,7 @@ function defaultConfig() {
             commitTypes: ['feat', 'fix', 'perf'],
             includeInvalidCommits: true,
             commitScopes: null,
-            commitIgnoreRegexPattern: null,
+            commitIgnoreRegexPattern: "^WIP ",
             headlines: {
                 "feat": "Features",
                 "fix": "Bug Fixes",

--- a/test/commands/commandChangelog.test.js
+++ b/test/commands/commandChangelog.test.js
@@ -97,3 +97,21 @@ test("commandChangelog - included because breaking", async () => {
         new RegExp(`BREAKING CHANGES\\s+-\\s+${commitBodyMessage}`, "g")
     );
 });
+
+test("commandChangelog - ignored by regex pattern", async () => {
+    // GIVEN
+    const commitType = "fix";
+    const commitMessage = "Just a work in progress";
+    const commitSubject = `${commitType}: ${commitMessage}`;
+
+    const commitBody = "WIP I want to be ignored";
+
+    // WHEN
+    const changelogString = await createSimpleChangelog(
+        commitSubject,
+        commitBody
+    );
+
+    // THEN
+    expect(changelogString).toMatch(/no relevant changes/);
+});


### PR DESCRIPTION
The defaultConfig() now has a valid commitIgnoreRegexPattern, that is the default of the documentation ("^WIP "). The parameter commitIgnoreRegex is set to a RegExp taking the configured pattern and having the multiline flag ("m"). I also added a test for a working WIP commit.

fixes issue #139