### PR TITLE
fix: msgRegex missing group error thrown with default configuration

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -27,7 +27,7 @@ function load(configFile) {
         conventionConfig.releaseTagGlobPattern = conventionOverride.releaseTagGlobPattern ||
             conventionConfig.releaseTagGlobPattern;
 
-        conventionConfig.msgRegex = RegExp(conventionOverride.commitMessageRegexPattern) || conventionConfig.msgRegex;
+        conventionConfig.msgRegex = RegExp(conventionOverride.commitMessageRegexPattern || conventionConfig.msgRegex);
         conventionConfig.commitTypes = conventionOverride.commitTypes || conventionConfig.commitTypes;
         conventionConfig.featureCommitTypes = conventionOverride.featureCommitTypes || conventionConfig.featureCommitTypes;
         conventionConfig.commitScopes = conventionOverride.commitScopes || conventionConfig.commitScopes;


### PR DESCRIPTION
See issue #164